### PR TITLE
fix(grok): use page.click() to avoid detached element in headed mode

### DIFF
--- a/src/providers/grok.ts
+++ b/src/providers/grok.ts
@@ -84,9 +84,9 @@ export const grokActions: ProviderActions = {
     await page.waitForTimeout(300);
 
     // Wait for submit button to become enabled
-    const sendButton = page.locator(`${SELECTORS.sendButton}:not([disabled])`).first();
-    await sendButton.waitFor({ state: 'visible', timeout: 5_000 });
-    await sendButton.click();
+    const sendSel = `${SELECTORS.sendButton}:not([disabled])`;
+    await page.locator(sendSel).first().waitFor({ state: 'visible', timeout: 5_000 });
+    await page.click(sendSel);
   },
 
   async captureResponse(


### PR DESCRIPTION
## Problem

When using `--headed` mode with the Grok provider, `submitPrompt()` consistently fails with:

```
Error: elementHandle.click: Element is not attached to the DOM
```

This happens because the submit button's element handle goes stale when React re-renders the DOM during Cloudflare Turnstile verification or page hydration.

## Fix

Replace the locator-based `.click()` (which holds a stale element reference) with `page.click(selector)`, which re-queries the DOM at click time.

## Testing

Tested on macOS with Playwright Chromium, both Expert and Heavy models, `--headed` mode. Before the fix: 100% failure rate. After: works reliably.