### PR TITLE
Fix config loading and avoid headless auth checks for ChatGPT/Claude

### DIFF
--- a/src/browser/mode.ts
+++ b/src/browser/mode.ts
@@ -1,0 +1,19 @@
+import type { ProviderName } from '../types.js';
+
+const HEADED_PROVIDERS = new Set<ProviderName>(['chatgpt', 'claude']);
+
+/**
+ * Resolve whether a provider should run headless for this invocation.
+ * Explicit --headed always wins. Some providers are more reliable with a
+ * visible browser because anti-bot checks or alternate DOM branches trigger
+ * under headless Chromium.
+ */
+export function resolveHeadlessMode(
+  providerName: ProviderName,
+  configHeadless: boolean,
+  headedOverride = false,
+): boolean {
+  if (headedOverride) return false;
+  if (HEADED_PROVIDERS.has(providerName)) return false;
+  return configHeadless;
+}

--- a/src/cli/login.ts
+++ b/src/cli/login.ts
@@ -3,6 +3,7 @@ import chalk from 'chalk';
 import { Command } from 'commander';
 import { chromium } from 'playwright';
 import { acquireProfileLock, launchBrowser } from '../browser/index.js';
+import { resolveHeadlessMode } from '../browser/mode.js';
 import { saveStorageState } from '../browser/state.js';
 import { loadConfig } from '../config.js';
 import { getSharedProfileDir } from '../paths.js';
@@ -26,7 +27,7 @@ export function createLoginCommand(): Command {
         const profileMode: ProfileMode = options?.isolatedProfile ? 'isolated' : config.profileMode;
 
         if (options?.status) {
-          await checkLoginStatus(profileMode);
+          await checkLoginStatus(profileMode, config.headless);
           return;
         }
 
@@ -206,7 +207,10 @@ async function loginAllWithTabs(
   }
 }
 
-async function checkLoginStatus(profileMode: ProfileMode = 'shared'): Promise<void> {
+async function checkLoginStatus(
+  profileMode: ProfileMode = 'shared',
+  configHeadless = true,
+): Promise<void> {
   console.log(chalk.bold('Login Status\n'));
   if (profileMode === 'shared') {
     console.log(chalk.dim('(shared profile mode — all providers use the same browser profile)\n'));
@@ -217,7 +221,7 @@ async function checkLoginStatus(profileMode: ProfileMode = 'shared'): Promise<vo
     try {
       const browser = await launchBrowser({
         provider: name,
-        headless: true,
+        headless: resolveHeadlessMode(name, configHeadless),
         url: provider.config.url,
         profileMode,
       });

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,7 +9,8 @@ export async function loadConfig(): Promise<AppConfig> {
   try {
     const raw = await readFile(configPath, 'utf-8');
     // Dynamic import JSON5 only when needed
-    const JSON5 = await import('json5');
+    const JSON5Module = await import('json5');
+    const JSON5 = JSON5Module.default ?? JSON5Module;
     const parsed = JSON5.parse(raw) as Partial<AppConfig>;
     return { ...DEFAULT_CONFIG, ...parsed };
   } catch {

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk';
 import { launchBrowser } from '../browser/index.js';
+import { resolveHeadlessMode } from '../browser/mode.js';
 import { loadConfig } from '../config.js';
 import { getProvider } from '../providers/index.js';
 import { createSession, saveBundle, saveResponse, updateSession } from '../session/index.js';
@@ -35,7 +36,7 @@ export async function runChat(options: ChatOptions): Promise<ChatResult> {
   const providerName = options.provider ?? config.defaultProvider;
   const provider = getProvider(providerName);
   const timeoutMs = options.timeoutMs ?? config.defaultTimeoutMs;
-  const headless = options.headed === true ? false : config.headless;
+  const headless = resolveHeadlessMode(providerName, config.headless, options.headed === true);
 
   // Build the bundle
   const bundle = await buildBundle({

--- a/tests/browser-mode.test.ts
+++ b/tests/browser-mode.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { resolveHeadlessMode } from '../src/browser/mode.js';
+
+describe('resolveHeadlessMode', () => {
+  it('forces headed mode for ChatGPT', () => {
+    expect(resolveHeadlessMode('chatgpt', true)).toBe(false);
+  });
+
+  it('forces headed mode for Claude', () => {
+    expect(resolveHeadlessMode('claude', true)).toBe(false);
+  });
+
+  it('keeps headless mode for Gemini when config prefers headless', () => {
+    expect(resolveHeadlessMode('gemini', true)).toBe(true);
+  });
+
+  it('honors explicit headed override for any provider', () => {
+    expect(resolveHeadlessMode('grok', true, true)).toBe(false);
+  });
+});

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,0 +1,50 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+describe('Config Loading', () => {
+  const originalEnv = process.env;
+  let tempHome = '';
+
+  beforeEach(async () => {
+    tempHome = await mkdtemp(path.join(os.tmpdir(), 'ten-x-chat-config-'));
+    process.env = {
+      ...originalEnv,
+      TEN_X_CHAT_HOME: tempHome,
+    };
+  });
+
+  afterEach(async () => {
+    process.env = originalEnv;
+    if (tempHome) await rm(tempHome, { recursive: true, force: true });
+  });
+
+  it('loads JSON config from disk', async () => {
+    await writeFile(
+      path.join(tempHome, 'config.json'),
+      JSON.stringify({ profileMode: 'isolated', headless: false }, null, 2),
+      'utf8',
+    );
+
+    const { loadConfig } = await import('../src/config.js');
+    const config = await loadConfig();
+
+    expect(config.profileMode).toBe('isolated');
+    expect(config.headless).toBe(false);
+  });
+
+  it('loads JSON5 config from disk', async () => {
+    await writeFile(
+      path.join(tempHome, 'config.json'),
+      '{\n        // provider profile mode\n        profileMode: "isolated",\n        headless: false,\n      }',
+      'utf8',
+    );
+
+    const { loadConfig } = await import('../src/config.js');
+    const config = await loadConfig();
+
+    expect(config.profileMode).toBe('isolated');
+    expect(config.headless).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- fix JSON5 config loading when the package is imported as an ESM namespace
- route ChatGPT and Claude through a visible browser for status checks and default chat runs
- add regression tests for config parsing and provider headless-mode selection

## Why
On my test machine, login succeeded for ChatGPT and Claude, but later login --status and default chat failed with "Not logged in".
The root causes were:
1. loadConfig() could silently fall back to defaults because import("json5") returned a namespace object in this runtime
2. ChatGPT and Claude profiles were being checked again in headless Chromium, which landed on Cloudflare / security-verification pages instead of the authenticated app UI

This keeps the default headless behavior for providers that still work well there, while avoiding false negatives and failed default chats for providers that require a visible browser.

## Validation
- npx vitest run tests/config.test.ts tests/browser-mode.test.ts tests/paths.test.ts tests/chatgpt-overlay.test.ts --reporter verbose
- npm run typecheck
